### PR TITLE
update byteorder to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ license = "MIT"
 exclude = ["data/*"]
 
 [dependencies]
-byteorder = "0.4"
+byteorder = "1.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,9 @@
-extern crate byteorder;
-
 use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IoError;
 use std::num::ParseIntError;
 use std::result::Result as StdResult;
 use std::str::Utf8Error;
-
-use self::byteorder::Error as ByteOrderError;
 
 /// A specialized Result type for metadata operations.
 pub type Result<T> = StdResult<T, Error>;
@@ -16,8 +12,6 @@ pub type Result<T> = StdResult<T, Error>;
 pub enum Error {
     /// An IO error occured. Contains `std::io::Error`.
     Io(IoError),
-    /// An error when parsing data to bytes. Contains `byteorder::Error`.
-    ByteOrder(ByteOrderError),
     /// An error when attempting to interpret a sequence of u8 as a string.
     FromUtf8(Utf8Error),
     /// An error when parsing an integer. Contains `std::num::ParseIntError`.
@@ -44,7 +38,6 @@ impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Io(ref err) => err.description(),
-            Error::ByteOrder(ref err) => err.description(),
             Error::ParseInt(ref err) => err.description(),
             Error::FromUtf8(ref err) => err.description(),
             Error::BadItemKind => "Unexpected item kind",
@@ -61,7 +54,6 @@ impl StdError for Error {
     fn cause(&self) -> Option<&StdError> {
         match *self {
             Error::Io(ref err) => Some(err),
-            Error::ByteOrder(ref err) => Some(err),
             Error::ParseInt(ref err) => Some(err),
             _ => None
         }
@@ -78,10 +70,6 @@ impl fmt::Display for Error {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         write!(out, "{}", self.description())
     }
-}
-
-impl From<ByteOrderError> for Error {
-    fn from(error: ByteOrderError) -> Error { Error::ByteOrder(error) }
 }
 
 impl From<IoError> for Error {

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,9 +1,7 @@
-extern crate byteorder;
-
 use std::ascii::{AsciiExt};
 use std::io::{Cursor, Write};
 
-use self::byteorder::{LittleEndian, WriteBytesExt};
+use byteorder::{LittleEndian, WriteBytesExt};
 
 use error::{Error, Result};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@
 
 #![warn(missing_docs)]
 
+extern crate byteorder;
+
 pub use error::{Result, Error};
 pub use item::{Item, ItemValue};
 pub use tag::{Tag, read, remove};

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,8 +1,6 @@
-extern crate byteorder;
-
 use std::io::{Read, Seek, SeekFrom};
 
-use self::byteorder::{LittleEndian, ReadBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt};
 
 use error::{Error, Result};
 use util::{probe_ape, probe_id3v1, probe_lyrics3v2, ID3V1_OFFSET};
@@ -84,9 +82,8 @@ impl Meta {
 
 #[cfg(test)]
 mod test {
-    extern crate byteorder;
     use std::io::{Cursor, Write};
-    use self::byteorder::{LittleEndian, WriteBytesExt};
+    use byteorder::{LittleEndian, WriteBytesExt};
     use super::{Meta, HAS_HEADER, IS_HEADER, HAS_NO_FOOTER};
 
     #[test]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,11 +1,9 @@
-extern crate byteorder;
-
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::str;
 
-use self::byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use error::{Error, Result};
 use item::{Item, KIND_BINARY, KIND_LOCATOR, KIND_TEXT};


### PR DESCRIPTION
Hi, 
due to conflicts on a project i use in which multiple crates depend on byteorder, because rust-ape depends on an older version, i had to update for my project, 
run tests and they pass, don't know if is anything sill missing