### PR TITLE
Allow reading/writing/removing from existing files

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -46,7 +46,7 @@ impl Item {
     fn new<S: Into<String>>(key: S, value: ItemValue) -> Result<Item> {
         let key = key.into();
         let len = key.len();
-        if len < 2 || len > 255 {
+        if !(2..=255).contains(&len) {
             return Err(Error::InvalidItemKeyLen);
         }
         if DENIED_KEYS.contains(&key.as_str()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,20 +10,20 @@
 //! ## Creating a tag
 //!
 //! ```no_run
-//! use ape::{write, Item, Tag};
+//! use ape::{Item, Tag, write_to_path};
 //!
 //! let mut tag = Tag::new();
 //! let item = Item::from_text("artist", "Artist Name").unwrap();
 //! tag.set_item(item);
-//! write(&tag, "path/to/file").unwrap();
+//! write_to_path(&tag, "path/to/file").unwrap();
 //! ```
 //!
 //! ## Reading a tag
 //!
 //! ```no_run
-//! use ape::read;
+//! use ape::read_from_path;
 //!
-//! let tag = read("path/to/file").unwrap();
+//! let tag = read_from_path("path/to/file").unwrap();
 //! let item = tag.item("artist").unwrap();
 //! println!("{:?}", item.value);
 //! ```
@@ -31,22 +31,22 @@
 //! ## Updating a tag
 //!
 //! ```no_run
-//! use ape::{read, write, Item};
+//! use ape::{Item, write_to_path, read_from_path};
 //!
 //! let path = "path/to/file";
-//! let mut tag = read(path).unwrap();
+//! let mut tag = read_from_path(path).unwrap();
 //! let item = Item::from_text("album", "Album Name").unwrap();
 //! tag.set_item(item);
 //! tag.remove_item("cover");
-//! write(&tag, path).unwrap();
+//! write_to_path(&tag, path).unwrap();
 //! ```
 //!
 //! ## Deleting a tag
 //!
 //! ```no_run
-//! use ape::remove;
+//! use ape::remove_from_path;
 //!
-//! remove("path/to/file").unwrap();
+//! remove_from_path("path/to/file").unwrap();
 //! ```
 //!
 
@@ -55,7 +55,7 @@
 pub use self::{
     error::{Error, Result},
     item::{Item, ItemValue},
-    tag::{read, remove, write, Tag},
+    tag::{read_from, read_from_path, remove_from, remove_from_path, write_to, write_to_path, Tag},
 };
 
 mod error;

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -145,7 +145,8 @@ pub fn write_to(tag: &Tag, file: &mut File) -> Result<()> {
         items.push(item.to_vec()?);
     }
     // APE tag items should be sorted ascending by size
-    items.sort_by(|a, b| a.len().cmp(&b.len()));
+    items.sort_by_key(|a| a.len());
+
     let mut size = 32; // Tag size including footer
 
     // Write items

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -92,7 +92,7 @@ impl IntoIterator for Tag {
     }
 }
 
-/// Attempts to write the APE to the file at the specified path.
+/// Attempts to write the APE tag to the file at the specified path.
 ///
 /// # Errors
 ///
@@ -108,7 +108,7 @@ pub fn write_to_path<P: AsRef<Path>>(tag: &Tag, path: P) -> Result<()> {
     Ok(())
 }
 
-/// Attempts to write the APE Tag to a File.
+/// Attempts to write the APE tag to a File.
 ///
 /// # Errors
 /// Same errors apply as [`write_to_path`]
@@ -176,7 +176,7 @@ pub fn write_to(tag: &Tag, file: &mut File) -> Result<()> {
     Ok(())
 }
 
-/// Attempts to read APE tag from the file at the specified path.
+/// Attempts to read an APE tag from the file at the specified path.
 ///
 /// # Errors
 ///

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -20,24 +20,24 @@ use std::{
 /// ## Creating a tag
 ///
 /// ```no_run
-/// use ape::{write, Item, Tag};
+/// use ape::{Item, Tag, write_to_path};
 ///
 /// let mut tag = Tag::new();
 /// let item = Item::from_text("artist", "Artist Name").unwrap();
 /// tag.set_item(item);
-/// write(&tag, "path/to/file").unwrap();
+/// write_to_path(&tag, "path/to/file").unwrap();
 /// ```
 /// # Updating a tag
 ///
 /// ```no_run
-/// use ape::{read, write, Item};
+/// use ape::{Item, read_from_path, write_to_path};
 ///
 /// let path = "path/to/file";
-/// let mut tag = read(path).unwrap();
+/// let mut tag = read_from_path(path).unwrap();
 /// let item = Item::from_text("album", "Album Name").unwrap();
 /// tag.set_item(item);
 /// tag.remove_item("cover");
-/// write(&tag, path).unwrap();
+/// write_to_path(&tag, path).unwrap();
 /// ```
 #[derive(Debug, Default)]
 pub struct Tag(Vec<Item>);
@@ -92,34 +92,51 @@ impl IntoIterator for Tag {
     }
 }
 
-/// Attempts to write the APE Tag to the file at the specified path.
+/// Attempts to write the APE to the file at the specified path.
 ///
 /// # Errors
 ///
 /// It is considered an error if there are no items in the tag.
-pub fn write<P: AsRef<Path>>(tag: &Tag, path: P) -> Result<()> {
+pub fn write_to_path<P: AsRef<Path>>(tag: &Tag, path: P) -> Result<()> {
     if tag.0.is_empty() {
         return Err(Error::EmptyTag);
     }
 
-    remove(&path)?;
+    let mut file = OpenOptions::new().read(true).write(true).open(path)?;
+    write_to(tag, &mut file)?;
 
-    let mut file = &OpenOptions::new().read(true).write(true).open(path)?;
+    Ok(())
+}
+
+/// Attempts to write the APE Tag to a File.
+///
+/// # Errors
+/// Same errors apply as [`write_to_path`]
+pub fn write_to(tag: &Tag, file: &mut File) -> Result<()> {
+    if tag.0.is_empty() {
+        return Err(Error::EmptyTag);
+    }
+
+    remove_from(file)?;
 
     // Keep ID3v1 and LYRICS3v2 (if any)
     let mut id3 = Vec::<u8>::new();
     let filesize = file.seek(SeekFrom::End(0))?;
-    if probe_id3v1(&mut file)? {
+
+    if probe_id3v1(file)? {
         let mut end_size: i64 = 128;
-        let lyrcis3v2_size = probe_lyrics3v2(&mut file)?;
+        let lyrcis3v2_size = probe_lyrics3v2(file)?;
+
         if lyrcis3v2_size != -1 {
             end_size += lyrcis3v2_size;
         }
+
         file.seek(SeekFrom::End(-end_size))?;
         file.take(end_size as u64).read_to_end(&mut id3)?;
         file.seek(SeekFrom::End(-end_size))?;
         file.set_len(filesize - end_size as u64)?;
     }
+
     file.seek(SeekFrom::End(0))?;
 
     // Convert items to bytes
@@ -146,6 +163,7 @@ pub fn write<P: AsRef<Path>>(tag: &Tag, path: P) -> Result<()> {
     file.write_u32::<LittleEndian>(tag.0.len() as u32)?;
     // Tag flags
     file.write_u32::<LittleEndian>(0)?;
+
     // Reserved
     for _ in 0..8 {
         file.write_u8(0)?;
@@ -153,6 +171,7 @@ pub fn write<P: AsRef<Path>>(tag: &Tag, path: P) -> Result<()> {
 
     // Write ID3v1 and LYRICS3v2 (if any)
     file.write_all(&id3)?;
+
     Ok(())
 }
 
@@ -171,28 +190,41 @@ pub fn write<P: AsRef<Path>>(tag: &Tag, path: P) -> Result<()> {
 /// # Examples
 ///
 /// ```no_run
-/// use ape::read;
+/// use ape::read_from_path;
 ///
-/// let tag = read("path/to/file").unwrap();
+/// let tag = read_from_path("path/to/file").unwrap();
 /// let item = tag.item("artist").unwrap();
 /// println!("{:?}", item.value);
 /// ```
-pub fn read<P: AsRef<Path>>(path: P) -> Result<Tag> {
-    let mut file = &File::open(path)?;
-    let meta = Meta::read(&mut file)?;
+pub fn read_from_path<P: AsRef<Path>>(path: P) -> Result<Tag> {
+    let mut file = OpenOptions::new().read(true).open(path)?;
+    read_from(&mut file)
+}
+
+/// Attempts to read an APE tag from a reader
+///
+/// # Errors
+/// Same errors apply as [`read_from_path`]
+pub fn read_from<R: Read + Seek>(reader: &mut R) -> Result<Tag> {
+    let meta = Meta::read(reader)?;
     let mut items = Vec::<Item>::new();
-    file.seek(SeekFrom::Start(meta.start_pos))?;
+
+    reader.seek(SeekFrom::Start(meta.start_pos))?;
+
     for _ in 0..meta.item_count {
-        let item_size = file.read_u32::<LittleEndian>()?;
-        let item_flags = file.read_u32::<LittleEndian>()?;
+        let item_size = reader.read_u32::<LittleEndian>()?;
+        let item_flags = reader.read_u32::<LittleEndian>()?;
         let mut item_key = Vec::<u8>::new();
-        let mut k = file.read_u8()?;
+        let mut k = reader.read_u8()?;
+
         while k != 0 {
             item_key.push(k);
-            k = file.read_u8()?;
+            k = reader.read_u8()?;
         }
+
         let mut item_value = Vec::<u8>::with_capacity(item_size as usize);
-        file.take(item_size as u64).read_to_end(&mut item_value)?;
+        reader.take(item_size as u64).read_to_end(&mut item_value)?;
+
         let item_key = str::from_utf8(&item_key)?;
         items.push(match (item_flags & 6) >> 1 {
             KIND_BINARY => Item::from_binary(item_key, item_value)?,
@@ -203,7 +235,8 @@ pub fn read<P: AsRef<Path>>(path: P) -> Result<Tag> {
             }
         });
     }
-    if file.seek(SeekFrom::Current(0))? != meta.end_pos {
+
+    if reader.seek(SeekFrom::Current(0))? != meta.end_pos {
         Err(Error::BadTagSize)
     } else {
         Ok(Tag(items))
@@ -220,26 +253,38 @@ pub fn read<P: AsRef<Path>>(path: P) -> Result<Tag> {
 /// # Examples
 ///
 /// ```no_run
-/// use ape::remove;
+/// use ape::remove_from_path;
 ///
-/// remove("path/to/file").unwrap();
+/// remove_from_path("path/to/file").unwrap();
 /// ```
-pub fn remove<P: AsRef<Path>>(path: P) -> Result<()> {
-    let mut file = &OpenOptions::new().read(true).write(true).open(path)?;
-    let meta = match Meta::read(&mut file) {
+pub fn remove_from_path<P: AsRef<Path>>(path: P) -> Result<()> {
+    let mut file = OpenOptions::new().read(true).write(true).open(path)?;
+    remove_from(&mut file)?;
+
+    Ok(())
+}
+
+/// Attempts to remove an APE tag from a File
+///
+/// # Errors
+/// Same errors apply as [`remove_from_path`]
+pub fn remove_from(file: &mut File) -> Result<()> {
+    let meta = match Meta::read(file) {
         Ok(meta) => meta,
-        Err(error) => match error {
-            Error::TagNotFound => {
-                // It's ok, nothing to remove.
-                return Ok(());
-            }
-            _ => {
-                return Err(error);
-            }
-        },
+        Err(error) => {
+            return match error {
+                Error::TagNotFound => {
+                    // It's ok, nothing to remove.
+                    Ok(())
+                }
+                _ => Err(error),
+            };
+        }
     };
+
     let mut size = meta.size as u64;
     let mut offset;
+
     match meta.position {
         MetaPosition::Header => {
             offset = 0;
@@ -253,31 +298,38 @@ pub fn remove<P: AsRef<Path>>(path: P) -> Result<()> {
             }
         }
     }
+
     let filesize = file.seek(SeekFrom::End(0))?;
     let movesize = filesize - offset - size;
+
     const BUFFER_SIZE: u64 = 65536;
+
     if movesize > 0 {
         file.flush()?;
         file.seek(SeekFrom::Start(offset + size))?;
+
         let mut buff = Vec::<u8>::with_capacity(BUFFER_SIZE as usize);
-        file.take(BUFFER_SIZE).read_to_end(&mut buff)?;
+        file.take(BUFFER_SIZE as u64).read_to_end(&mut buff)?;
+
         while !buff.is_empty() {
             file.seek(SeekFrom::Start(offset))?;
             file.write_all(&buff)?;
             offset += buff.len() as u64;
             file.seek(SeekFrom::Start(offset + size))?;
             buff.clear();
-            file.take(BUFFER_SIZE).read_to_end(&mut buff)?;
+            file.take(BUFFER_SIZE as u64).read_to_end(&mut buff)?;
         }
     }
+
     file.set_len(filesize - size)?;
     file.flush()?;
+
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
-    use super::{read, remove, write, Tag};
+    use super::{read_from_path, remove_from_path, write_to_path, Tag};
     use crate::item::{Item, ItemValue};
     use std::{
         fs::{remove_file, File},
@@ -287,10 +339,13 @@ mod test {
     #[test]
     fn items() {
         let mut tag = Tag::new();
-        let item = Item::from_text("key", "value").unwrap();
         assert_eq!(0, tag.0.len());
+
+        let item = Item::from_text("key", "value").unwrap();
+
         tag.set_item(item);
         assert_eq!(1, tag.0.len());
+
         assert_eq!(
             "value",
             match tag.item("key").unwrap().value {
@@ -312,9 +367,9 @@ mod test {
 
         let mut tag = Tag::new();
         tag.set_item(Item::from_text("key", "value").unwrap());
-        write(&tag, path).unwrap();
+        write_to_path(&tag, path).unwrap();
 
-        let tag = read(path).unwrap();
+        let tag = read_from_path(path).unwrap();
         assert_eq!(1, tag.0.len());
         assert_eq!(
             "value",
@@ -324,8 +379,8 @@ mod test {
             }
         );
 
-        remove(path).unwrap();
-        match read(path) {
+        remove_from_path(path).unwrap();
+        match read_from_path(path) {
             Err(_) => {}
             Ok(_) => panic!("The tag wasn't removed!"),
         };
@@ -335,24 +390,24 @@ mod test {
 
     #[test]
     fn write_failed_with_empty_tag() {
-        let err = write(&Tag::new(), "data/empty").unwrap_err().to_string();
+        let err = write_to_path(&Tag::new(), "data/empty").unwrap_err().to_string();
         assert_eq!(err, "unable to perform operations on empty tag");
     }
 
     #[test]
     fn read_failed_with_bad_item_kind() {
-        let err = read("data/bad-item-kind.apev2").unwrap_err().to_string();
+        let err = read_from_path("data/bad-item-kind.apev2").unwrap_err().to_string();
         assert_eq!(err, "unexpected item kind");
     }
 
     #[test]
     fn read_failed_with_bad_tag_size() {
-        let err = read("data/bad-tag-size.apev2").unwrap_err().to_string();
+        let err = read_from_path("data/bad-tag-size.apev2").unwrap_err().to_string();
         assert_eq!(err, "APE header contains invalid tag size");
     }
 
     #[test]
     fn remove_for_no_tag_is_ok() {
-        remove("data/no-tag.apev2").unwrap();
+        remove_from_path("data/no-tag.apev2").unwrap();
     }
 }


### PR DESCRIPTION
Replace read/write/remove with read_from_path/write_from_path/remove_from_path and add read_from/write_to/remove_from so existing files can be used.