### PR TITLE
Implement Clone for all structures

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -11,7 +11,7 @@ const DENIED_KEYS: [&str; 4] = ["ID3", "TAG", "OggS", "MP+"];
 /// Represents an [APE Item Value][1]
 ///
 /// [1]: http://wiki.hydrogenaud.io/index.php?title=APE_Item_Value
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ItemValue {
     /// Binary data. Unrecommended to use.
     Binary(Vec<u8>),
@@ -24,7 +24,7 @@ pub enum ItemValue {
 /// Represents an [APE Tag Item][1].
 ///
 /// [1]: http://wiki.hydrogenaud.io/index.php?title=APE_Tag_Item
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Item {
     /// Item key for accessing special meta-information in an audio file.
     ///

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -41,7 +41,7 @@ use std::{
 /// tag.remove_item("cover");
 /// write_to_path(&tag, path).unwrap();
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Tag(Vec<Item>);
 
 impl Tag {


### PR DESCRIPTION
This makes the `Tag` structure (and its contained data types) clonable. The implementation is entirely derived by the rust compiler as all data structure used already implement the trait `Clone`